### PR TITLE
Error messages in parsing variables

### DIFF
--- a/xs/src/libslic3r/PlaceholderParser.cpp
+++ b/xs/src/libslic3r/PlaceholderParser.cpp
@@ -623,7 +623,7 @@ namespace client
             expr<Iterator>                  &output)
         {
             if (opt.opt->is_vector())
-                ctx->throw_exception("Referencing a scalar variable in a vector context", opt.it_range);
+                ctx->throw_exception("Referencing a vector variable when scalar is expected", opt.it_range);
             switch (opt.opt->type()) {
             case coFloat:   output.set_d(opt.opt->getFloat());   break;
             case coInt:     output.set_i(opt.opt->getInt());     break;
@@ -648,7 +648,7 @@ namespace client
             expr<Iterator>                  &output)
         {
             if (opt.opt->is_scalar())
-                ctx->throw_exception("Referencing a vector variable in a scalar context", opt.it_range);
+                ctx->throw_exception("Referencing a scalar variable when vector is expected", opt.it_range);
             const ConfigOptionVectorBase *vec = static_cast<const ConfigOptionVectorBase*>(opt.opt);
             if (vec->empty())
                 ctx->throw_exception("Indexing an empty vector variable", opt.it_range);


### PR DESCRIPTION
Making error messages more clear when a vector or scalar is found in macro parsing, and the other type is expected.